### PR TITLE
Fix GFM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,76 +1,74 @@
-#Design patterns in yuml
+# Design patterns in yUML
 
-##Abstract Factory
+> Design patterns written down using [yUML](https://github.com/jaime-olivares/yuml-diagram/wiki)
+
+## Abstract Factory
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/abstractFactory.png)
 
-```
+```yuml
 [＜＜interface＞＞;AbstractFactory|+createProduct();]^-.-[ConcreteFactory|+createProduct();],
 [＜＜interface＞＞;AbstractProduct]^-.-[ConcreteProduct]
 ```
 
-##Builder
+## Builder
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/builder.png)
 
-```
+```yuml
 [Director|+build();]++-[Builder|+buildPart();], [Builder]^-.-[ConcreteBuilder|+buildPart();+getResult():Product;]
 ```
 
-##FactoryMethod
+## FactoryMethod
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/factoryMethod.png)
 
-```
+```yuml
 [Creator|+factoryMethod():Product;]^-[ConcreteCreator|+factoryMethod():Product;]
 ```
 
-Prototype
+## Prototype
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/prototype.png)
 
-```
+```yuml
 [＜＜interface＞＞;Prototype|+clone():Prototype;]^-.-[ConcretePrototypeB|+clone():Prototype;],
 [＜＜interface＞＞;Prototype|+clone():Prototype;]^-.-[ConcretePrototypeA|+clone():Prototype;]
 ```
 
-##Singleton
+## Singleton
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/singleton.png)
 
-```
+```yuml
 [Singleton|-instance:Singleton = null|-Singleton();+getInstance():Singleton;]
 ```
 
-##Adapter
+## Adapter
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/adapter.png)
 
-```
+```yuml
 [＜＜interface＞＞;Target|+request();]^-.-[Adapter|+request();],
 [Adapter]-^[Adaptee|+specificRequest();]
 ```
 
-##Bridge
+## Bridge
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/bridge.png)
 
-```
+```yuml
 [Abstraction|-impl:Implementor;+function()]^-[RefinedAbstraction |+refinedFunction();],
 [Abstraction]<>-[Implementor|+implementation();],
 [Implementor]^-[ConceteImplementor|+implementation();]
 ```
 
-##Composite
+## Composite
 
 ![alt tag](https://raw.githubusercontent.com/stillerr/yuml-design-patterns/master/composite.png)
 
-```
+```yuml
 [Component|+opertation()]^-[Leaf|+operation();],
 [Component]^-[Composite|+operation();+add();+remove();+getChild()],
 [Component]0..*-<>1[Composite]
 ```
-
-
-
-


### PR DESCRIPTION
This fixes github flavored markdown issues. It also adds a short decsription of the content with a link to the [yUML syntax](https://github.com/jaime-olivares/yuml-diagram/wiki)